### PR TITLE
Feat: Calendar 기능 API 추가

### DIFF
--- a/src/main/java/EatPic/spring/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/EatPic/spring/domain/calendar/controller/CalendarController.java
@@ -1,0 +1,39 @@
+package EatPic.spring.domain.calendar.controller;
+
+import EatPic.spring.domain.calendar.dto.CalendarDayResponse;
+import EatPic.spring.domain.calendar.service.CalendarService;
+import EatPic.spring.domain.card.repository.CardRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController  //API요청을 처리하는 컨트롤러임을 명시!
+@RequiredArgsConstructor
+@RequestMapping("/api/calendar")  //이 클래스에서 모든 API경로 앞에 공통적으로 붙을 주소 설정!!
+@Tag(name = "Calendar", description = "캘린더 관련 API")
+public class CalendarController {
+
+  private final CalendarService calendarService;
+
+
+  @Operation(summary = "캘린더 화면 데이터 조회",  //Operation의 구성요소 중 하나로, API에 대한 한줄요약.
+      description = "캘린더에서 기록이 있는 날짜에 해당하는 대표이미지를 불러오는 API") //상세설명
+  @GetMapping
+  public List<CalendarDayResponse> getCalendar(
+      //@AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestParam int year,
+      @RequestParam int month
+  ) {
+    Long userId = 1L; //Long userId = userDetails.getUser().getId(); //로그인 구현 시 이렇게 바꾸기
+    //User user = userDetails.getUser(); //아니면 이렇게 해서 객체 자체를 넘기기 (이게 일반적인 방법)
+    return calendarService.getCalendar(userId, year, month);
+  }
+
+
+
+}

--- a/src/main/java/EatPic/spring/domain/calendar/dto/CalendarDayResponse.java
+++ b/src/main/java/EatPic/spring/domain/calendar/dto/CalendarDayResponse.java
@@ -1,0 +1,18 @@
+package EatPic.spring.domain.calendar.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(title = "CalendarDayResponse: 날짜별 대표 이미지 응답 DTO")
+public class CalendarDayResponse {
+  @Schema(description = "해당 날짜", example = "2025-07-02")
+  private LocalDate date;
+
+  @Schema(description = "대표 이미지 URL", example = "https://example.com/image.jpg")
+  private String imageUrl;
+
+}

--- a/src/main/java/EatPic/spring/domain/calendar/service/CalendarService.java
+++ b/src/main/java/EatPic/spring/domain/calendar/service/CalendarService.java
@@ -1,0 +1,87 @@
+package EatPic.spring.domain.calendar.service;
+
+import EatPic.spring.domain.calendar.dto.CalendarDayResponse;
+import EatPic.spring.domain.card.entity.Card;
+import EatPic.spring.domain.card.entity.CardImage;
+import EatPic.spring.domain.card.entity.Meal;
+import EatPic.spring.domain.card.repository.CardRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CalendarService {
+  private final CardRepository cardRepository;
+
+  public List<CalendarDayResponse> getCalendar(Long userId, int year, int month) {
+    // 현재 월과 이전 월 구하기
+    YearMonth currentMonth = YearMonth.of(year, month);
+    YearMonth previousMonth = currentMonth.minusMonths(1);
+
+    // 시작 날짜: 이전달 1일 00:00 / 끝 날짜: 이번달 말일 23:59:59
+    LocalDateTime start = previousMonth.atDay(1).atStartOfDay();
+    LocalDateTime end = currentMonth.atEndOfMonth().atTime(LocalTime.MAX);
+
+    // 해당 기간 동안의 카드들 조회
+    List<Card> cards = cardRepository.findByUserIdAndCreatedAtBetween(userId, start, end);
+
+    // 날짜별로 그룹화 (날짜 기준, 카드 리스트)
+    Map<LocalDate, List<Card>> grouped = cards.stream()
+        .collect(Collectors.groupingBy(card -> card.getCreatedAt().toLocalDate()));
+
+    // 날짜순 정렬
+    List<CalendarDayResponse> result = new ArrayList<>();
+
+    grouped.forEach((date, cardList) -> {
+      // 아침 → 점심 → 저녁 → 간식 순으로 첫 식사 선택
+      Optional<Card> firstMealCard = getFirstMealCard(cardList);
+
+      // 대표 이미지 가져오기
+      String imageUrl = firstMealCard
+          .flatMap(card -> card.getCardImages().stream().findFirst())
+          .map(CardImage::getCardImageUrl)
+          .orElse(null);
+
+      result.add(CalendarDayResponse.builder()
+          .date(date)
+          .imageUrl(imageUrl)
+          .build());
+    });
+
+    // 최신 날짜가 아래로 오도록 정렬
+    result.sort(Comparator.comparing(CalendarDayResponse::getDate).reversed());
+
+    return result;
+  }
+
+  // 식사 우선순위 정해서 대표 카드 선택
+  private Optional<Card> getFirstMealCard(List<Card> cards) {
+    List<Meal> priority = List.of(
+        Meal.BREAKFAST,
+        Meal.LUNCH,
+        Meal.DINNER,
+        Meal.SNACK
+    );
+    for (Meal mealType : priority) {
+      for (Card card : cards) {
+        if (card.getMeal() == mealType) {
+          return Optional.of(card);
+        }
+      }
+    }
+    return Optional.empty();
+  }
+
+}

--- a/src/main/java/EatPic/spring/domain/card/entity/Card.java
+++ b/src/main/java/EatPic/spring/domain/card/entity/Card.java
@@ -61,4 +61,7 @@ public class Card extends BaseEntity {
     @OneToMany(mappedBy = "card")
     private List<CardHashtag> cardHashtags = new ArrayList<>();
 
+    @OneToMany(mappedBy = "card", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<CardImage> cardImages = new ArrayList<>();
+
 }

--- a/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
@@ -1,0 +1,11 @@
+package EatPic.spring.domain.card.repository;
+
+import EatPic.spring.domain.card.entity.Card;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardRepository extends JpaRepository<Card, Long> {
+
+  List<Card> findByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #15 

## 📝작업 내용

> 사용자의 이번 달 및 전달 기록을 불러옵니다.
> 기록이 있는 날짜에는 해당 날의 첫 번째 식사의 대표 이미지를 함께 반환합니다.
> 캘린더 무한 스크롤을 위한 이전 달 조회에도 사용됩니다.


> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 로그인/회원가입 부분은 안입힘 (주석처리 참고)