### PR TITLE
Feat: 추천 Pic카드 조회 기능 추가

### DIFF
--- a/src/main/java/EatPic/spring/domain/card/controller/CardController.java
+++ b/src/main/java/EatPic/spring/domain/card/controller/CardController.java
@@ -6,6 +6,7 @@ import EatPic.spring.domain.card.dto.response.CardResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardDetailResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CreateCardResponse;
+import EatPic.spring.domain.card.dto.response.CardResponse.RecommendCardResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.TodayCardResponse;
 import EatPic.spring.domain.card.entity.Card;
 import EatPic.spring.domain.card.repository.CardRepository;
@@ -111,6 +112,13 @@ public class CardController {
                                                                      @RequestParam(required = false) Long cursor,
                                                                      @RequestParam(defaultValue = "15") int size) {
     return ApiResponse.onSuccess(cardService.getCardFeedByCursor(userId,size,cursor));
+  }
+
+
+  @Operation(summary = "추천 픽카드 조회", description = "홈화면 진입 시 추천 픽카드 최대 10개를 조회합니다.")
+  @GetMapping("/recommended-cards")
+  public ApiResponse<List<RecommendCardResponse>> getRecommendedCards() {
+    return ApiResponse.onSuccess(cardService.getRecommendedCardPreviews());
   }
 
 

--- a/src/main/java/EatPic/spring/domain/card/dto/response/CardResponse.java
+++ b/src/main/java/EatPic/spring/domain/card/dto/response/CardResponse.java
@@ -211,6 +211,20 @@ public class CardResponse {
     private List<CardFeedResponse> cardFeedList;
   }
 
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(title = "RecommendCardResponse: 추천 카드 응답 dto")
+  public static class RecommendCardResponse {
+    @Schema(description = "카드 ID", example = "12")
+    private Long cardId;
+
+    @Schema(description = "카드 이미지 URL", example = "https://cdn.eatpic.com/cards/12.jpg")
+    private String cardImageUrl;
+
+  }
+
 
 
 }

--- a/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
@@ -45,4 +45,12 @@ public interface CardRepository extends JpaRepository<Card, Long> {
   boolean existsByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
 
   List<Card> findByUser(User user);
+
+  @Query("""
+    SELECT c FROM Card c
+    JOIN Reaction r ON r.card = c
+    GROUP BY c
+    HAVING COUNT(r) >= 1
+""")
+  List<Card> findCardsWithReactionCountOver1();  //초기 테스트로 1개로 수정 (기존은 100개)
 }

--- a/src/main/java/EatPic/spring/domain/card/service/CardService.java
+++ b/src/main/java/EatPic/spring/domain/card/service/CardService.java
@@ -5,6 +5,7 @@ import EatPic.spring.domain.card.dto.request.CardCreateRequest.CardUpdateRequest
 import EatPic.spring.domain.card.dto.response.CardResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardDetailResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedResponse;
+import EatPic.spring.domain.card.dto.response.CardResponse.RecommendCardResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.TodayCardResponse;
 import EatPic.spring.domain.user.entity.User;
 import java.util.List;
@@ -17,4 +18,5 @@ public interface CardService {
   List<TodayCardResponse> getTodayCards(Long userId);
   CardDetailResponse updateCard(Long cardId, Long userId, CardUpdateRequest request);
   CardResponse.PagedCardFeedResponseDto getCardFeedByCursor(Long userId, int size, Long cursor);
+  List<RecommendCardResponse> getRecommendedCardPreviews();
 }

--- a/src/main/java/EatPic/spring/domain/card/service/CardServiceImpl.java
+++ b/src/main/java/EatPic/spring/domain/card/service/CardServiceImpl.java
@@ -8,6 +8,7 @@ import EatPic.spring.domain.card.dto.request.CardCreateRequest.CardUpdateRequest
 import EatPic.spring.domain.card.dto.response.CardResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardDetailResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedResponse;
+import EatPic.spring.domain.card.dto.response.CardResponse.RecommendCardResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.TodayCardResponse;
 import EatPic.spring.domain.card.entity.Card;
 import EatPic.spring.domain.card.entity.Meal;
@@ -25,6 +26,7 @@ import EatPic.spring.global.common.exception.handler.ExceptionHandler;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -282,5 +284,21 @@ public class CardServiceImpl implements CardService {
                 .toList();
 
         return CardConverter.toPagedCardFeedResponseDTto(userId,cardSlice,feedList);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<RecommendCardResponse> getRecommendedCardPreviews() {
+        List<Card> cards = cardRepository.findCardsWithReactionCountOver1();
+
+        // 랜덤 셔플 후 최대 10개 추출
+        Collections.shuffle(cards);
+        return cards.stream()
+            .limit(10)
+            .map(card -> new RecommendCardResponse(
+                card.getId(),
+                card.getCardImageUrl() // 첫 이미지 URL 가져오는 메서드 필요
+            ))
+            .toList();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #100

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
홈화면 진입 시 추천 pic 카드 조회하는 api
기준 : 총 반응 수 100개 이상인 카드 중 10개를 랜덤으로 선택
테스트를 위해 100개 -> 1개로 코드 구현해둠.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
