### PR TITLE
Feat: 검색 범위가 전체인 경우에서 해시태그 검색하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,6 @@ out/
 ### VS Code ###
 .vscode/
 
+### application.yml ###
 */application.yml
+/src/main/resources/application.yml

--- a/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
+++ b/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
@@ -53,14 +53,17 @@ public class SearchController {
         SearchResponseDTO.GetAccountListResponseDto result = searchService.getAccountInFollow(query, limit, cursor, userId);
         return ApiResponse.onSuccess(result);    // 리턴 부분 제대로 작동하는지 확인하기!
     }
-//
+
     @Operation(summary = "검색 범위가 전체인 경우에서 해시태그 검색", description = "전체 - 해시태그 검색 api")
-    @GetMapping("")
-    public ResponseEntity<String> searchHashtagInAll(
+    @GetMapping("/all/hashtag")
+    public ApiResponse<SearchResponseDTO.GetHashtagListResponseDto> searchHashtagInAll(
             @RequestParam(value = "query") String query,
             @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
-            @RequestParam(value = "cursor", required = false) Long cursor) {
-
+            @RequestParam(value = "cursor", required = false) Long cursor
+    ) {
+        Long userId = 1L;
+        SearchResponseDTO.GetHashtagListResponseDto result = searchService.getHashtagInAll(query, limit, cursor);
+        return ApiResponse.onSuccess(result);    // 리턴 부분 제대로 작동하는지 확인하기!
     }
 //
 //    @Operation(summary = "검색범위가 유저가 팔로우한 사용자인 경우에서 해시태그 검색", description = "팔로우 - 해시태그 검색 api")

--- a/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
+++ b/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
@@ -48,11 +48,14 @@ public class SearchController {
 //
 //    }
 //
-//    @Operation(summary = "검색 범위가 전체인 경우에서 해시태그 검색", description = "전체 - 해시태그 검색 api")
-//    @GetMapping("")
-//    public ResponseEntity<String> searchHashtagInAll() {
-//
-//    }
+    @Operation(summary = "검색 범위가 전체인 경우에서 해시태그 검색", description = "전체 - 해시태그 검색 api")
+    @GetMapping("")
+    public ResponseEntity<String> searchHashtagInAll(
+            @RequestParam(value = "query") String query,
+            @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
+            @RequestParam(value = "cursor", required = false) Long cursor) {
+
+    }
 //
 //    @Operation(summary = "검색범위가 유저가 팔로우한 사용자인 경우에서 해시태그 검색", description = "팔로우 - 해시태그 검색 api")
 //    @GetMapping("")

--- a/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
+++ b/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
@@ -55,7 +55,7 @@ public class SearchController {
     }
 
     @Operation(summary = "검색 범위가 전체인 경우에서 해시태그 검색", description = "전체 - 해시태그 검색 api")
-    @GetMapping("/all/hashtag")
+    @GetMapping("/all/hashtag-search")
     public ApiResponse<SearchResponseDTO.GetHashtagListResponseDto> searchHashtagInAll(
             @RequestParam(value = "query") String query,
             @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,

--- a/src/main/java/EatPic/spring/domain/card/converter/CardConverter.java
+++ b/src/main/java/EatPic/spring/domain/card/converter/CardConverter.java
@@ -10,6 +10,7 @@ import EatPic.spring.domain.card.dto.response.CardResponse.TodayCardResponse;
 import EatPic.spring.domain.card.dto.response.SearchResponseDTO;
 import EatPic.spring.domain.card.entity.Card;
 import EatPic.spring.domain.card.mapping.CardHashtag;
+import EatPic.spring.domain.hashtag.entity.Hashtag;
 import EatPic.spring.domain.reaction.entity.Reaction;
 import EatPic.spring.domain.user.entity.User;
 import org.springframework.data.domain.Slice;
@@ -127,4 +128,13 @@ public class CardConverter {
                 .cardFeedList(feedList)
                 .build();
     }
+
+    public static SearchResponseDTO.GetHashtagResponseDto toHashtagDto(Hashtag hashtag, long cardCount) {
+        return SearchResponseDTO.GetHashtagResponseDto.builder()
+                .hashtagId(hashtag.getId())
+                .hashtagName(hashtag.getHashtagName())
+                .card_count(cardCount)
+                .build();
+    }
+
 }

--- a/src/main/java/EatPic/spring/domain/card/dto/request/CardCreateRequest.java
+++ b/src/main/java/EatPic/spring/domain/card/dto/request/CardCreateRequest.java
@@ -3,6 +3,7 @@ package EatPic.spring.domain.card.dto.request;
 import EatPic.spring.domain.card.entity.Meal;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -27,6 +28,7 @@ public class CardCreateRequest {
     private String memo;                // 메모
     private String recipe;              // 레시피 내용
     private Meal meal;                // 식사 종류 (breakfast, dinner, lunch, snack)
+    private List<String> hashtags; // 사용자가 선택/생성한 해시태그 목록 (이름 기준)
   }
 
   @Builder

--- a/src/main/java/EatPic/spring/domain/card/dto/response/SearchResponseDTO.java
+++ b/src/main/java/EatPic/spring/domain/card/dto/response/SearchResponseDTO.java
@@ -76,7 +76,14 @@ public class SearchResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetHashtagResponseDto {
+        @JsonProperty("hashtag_id")
+        private Long hashtagId;
 
+        @JsonProperty("hashtag_name")
+        private String hashtagName;
+
+        @JsonProperty("card_count")
+        private Long card_count;
     }
 
     // 탐색하기 검색창에서 검색 범위가 전체일 때 해시태그 검색하기 (해시태그 여러 개 리스트로..)
@@ -85,6 +92,9 @@ public class SearchResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class GetHashtagListResponseDto {
-
+        private List<GetHashtagResponseDto> hashtags;
+        private Long nextCursor;
+        private int size;
+        private boolean hasNext;
     }
 }

--- a/src/main/java/EatPic/spring/domain/card/dto/response/SearchResponseDTO.java
+++ b/src/main/java/EatPic/spring/domain/card/dto/response/SearchResponseDTO.java
@@ -1,6 +1,7 @@
 package EatPic.spring.domain.card.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.persistence.Column;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -67,5 +68,23 @@ public class SearchResponseDTO {
         private Long nextCursor;
         private int size;
         private boolean hasNext;
+    }
+
+    // 탐색하기 검색창에서 검색 범위가 전체일 때 해시태그 검색하기 (해시태그 하나 ver)
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetHashtagResponseDto {
+
+    }
+
+    // 탐색하기 검색창에서 검색 범위가 전체일 때 해시태그 검색하기 (해시태그 여러 개 리스트로..)
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetHashtagListResponseDto {
+
     }
 }

--- a/src/main/java/EatPic/spring/domain/card/entity/Card.java
+++ b/src/main/java/EatPic/spring/domain/card/entity/Card.java
@@ -61,6 +61,7 @@ public class Card extends BaseEntity {
     @Column(name = "isShared", nullable = false)
     private Boolean isShared = true;        // default: true
 
+    // 해시태그 관련 리스트
     @OneToMany(mappedBy = "card")
     private List<CardHashtag> cardHashtags = new ArrayList<>();
 

--- a/src/main/java/EatPic/spring/domain/card/repository/CardHashtagRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardHashtagRepository.java
@@ -3,6 +3,9 @@ package EatPic.spring.domain.card.repository;
 import EatPic.spring.domain.card.entity.Card;
 import EatPic.spring.domain.card.mapping.CardHashtag;
 import java.util.List;
+import java.util.Optional;
+
+import EatPic.spring.domain.hashtag.entity.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CardHashtagRepository extends JpaRepository<CardHashtag, Long> {

--- a/src/main/java/EatPic/spring/domain/card/repository/CardHashtagRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardHashtagRepository.java
@@ -11,6 +11,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface CardHashtagRepository extends JpaRepository<CardHashtag, Long> {
 
   List<CardHashtag> findAllByCardId(Long cardId);
-
   List<CardHashtag> findByCard(Card card);
+
+  List<CardHashtag> findByHashtag(Hashtag hashtag);      // Hashtag 객체
+  List<CardHashtag> findByHashtagId(Long hashtagId);      // Hashtag의 PK값
 }

--- a/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
@@ -2,6 +2,7 @@ package EatPic.spring.domain.card.repository;
 
 import EatPic.spring.domain.card.entity.Card;
 import EatPic.spring.domain.card.entity.Meal;
+import EatPic.spring.domain.card.mapping.CardHashtag;
 import EatPic.spring.domain.user.entity.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -54,4 +55,16 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     HAVING COUNT(r) >= 1
 """)
   List<Card> findCardsWithReactionCountOver1();  //초기 테스트로 1개로 수정 (기존은 100개)
+
+  @Query("""
+    SELECT COUNT(c)
+    FROM CardHashtag ch
+    JOIN ch.card c
+    WHERE ch.hashtag.id = :hashtagId
+      AND c.isDeleted = false
+      AND c.isShared = true
+""")
+  Long countCardsByHashtag(@Param("hashtagId") Long hashtagId);
+
+
 }

--- a/src/main/java/EatPic/spring/domain/card/repository/HashtagRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/HashtagRepository.java
@@ -1,10 +1,25 @@
 package EatPic.spring.domain.card.repository;
 
 import EatPic.spring.domain.hashtag.entity.Hashtag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
     Optional<Hashtag> findByHashtagName(String hashtagName);
+
+    @Query("""
+    SELECT h
+    FROM Hashtag h
+    WHERE h.hashtagName LIKE :query
+      AND (:cursor IS NULL OR h.id > :cursor)
+    ORDER BY h.id ASC
+""")
+    Slice<Hashtag> searchHashtagInAll(@Param("query") String query,
+                                      @Param("cursor") Long cursor,
+                                      Pageable pageable);
 }

--- a/src/main/java/EatPic/spring/domain/card/repository/HashtagRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/HashtagRepository.java
@@ -1,0 +1,10 @@
+package EatPic.spring.domain.card.repository;
+
+import EatPic.spring.domain.hashtag.entity.Hashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
+    Optional<Hashtag> findByHashtagName(String hashtagName);
+}

--- a/src/main/java/EatPic/spring/domain/card/service/CardServiceImpl.java
+++ b/src/main/java/EatPic/spring/domain/card/service/CardServiceImpl.java
@@ -151,7 +151,7 @@ public class CardServiceImpl implements CardService {
         Card savedCard = cardRepository.save(newCard);
 
         // 1. 해시태그 연결 (추가)
-        connectHashtagsToCard(newcard, request.getHashtags(), user);
+        connectHashtagsToCard(newCard, request.getHashtags(), user);
 
         // 뱃지 획득 부분 처리
 

--- a/src/main/java/EatPic/spring/domain/card/service/SearchService.java
+++ b/src/main/java/EatPic/spring/domain/card/service/SearchService.java
@@ -3,8 +3,9 @@ package EatPic.spring.domain.card.service;
 import EatPic.spring.domain.card.dto.response.SearchResponseDTO;
 
 public interface SearchService {
+
     SearchResponseDTO.GetCardListResponseDto getAllCards(int limit, Long cursor);
-    SearchResponseDTO.GetAccountListResponseDto getAccountInFollow(Long userId, String query, int limit, Long cursor);
     SearchResponseDTO.GetAccountListResponseDto getAccountInAll(String query, int limit, Long cursor);
     SearchResponseDTO.GetAccountListResponseDto getAccountInFollow(String query, int limit, Long cursor, Long userId);
+    SearchResponseDTO.GetHashtagListResponseDto getHashtagInAll(String query, int limit, Long cursor);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #41

## 📝작업 내용

<img width="1907" height="663" alt="image" src="https://github.com/user-attachments/assets/507380ae-4b79-4e4c-b4cf-63b48207c0da" />

> 기본 해시태그들은 데이터를 깔아둔 상태입니다.
> 아, 참고로 저희 user_id 1인 유저는 ADMIN으로 두고 사용합니다.

<img width="601" height="527" alt="image" src="https://github.com/user-attachments/assets/22abcbcb-81f6-47e4-8da6-5a454d1db36b" />

> 검색할 때는 해시태그명으로 검색을 하고 해시태그명을 포함한 저장된 게시글(카드)들의 개수를 세서 card_count로 반환합니다.