### PR TITLE
Refactor: card delete 관련 코드 수정

### DIFF
--- a/src/main/java/EatPic/spring/domain/card/controller/CardController.java
+++ b/src/main/java/EatPic/spring/domain/card/controller/CardController.java
@@ -3,6 +3,7 @@ package EatPic.spring.domain.card.controller;
 import EatPic.spring.domain.card.dto.request.CardCreateRequest;
 import EatPic.spring.domain.card.dto.request.CardCreateRequest.CardUpdateRequest;
 import EatPic.spring.domain.card.dto.response.CardResponse;
+import EatPic.spring.domain.card.dto.response.CardResponse.CardDeleteResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardDetailResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CreateCardResponse;
@@ -91,12 +92,12 @@ public class CardController {
 
   @DeleteMapping("/{cardId}")
   @Operation(summary = "카드 삭제", description = "카드를 소프트 삭제 처리합니다.")
-  public ApiResponse<Void> deleteCard(
+  public ApiResponse<CardDeleteResponse> deleteCard(
           HttpServletRequest request,
           @PathVariable(name = "cardId") Long cardId) {
     User user = userService.getLoginUser(request);
-    cardService.deleteCard(cardId, user.getId());
-    return ApiResponse.onSuccess(null);
+    CardDeleteResponse response = cardService.deleteCard(cardId, user.getId());
+    return ApiResponse.onSuccess(response);
   }
 
   @Operation(summary = "오늘의 식사 카드 조회", description = "홈 진입 시, 오늘 등록된 식사 카드들을 조회합니다.")
@@ -109,7 +110,7 @@ public class CardController {
   }
 
   @Operation(summary = "픽카드 수정", description = "카드의 메모, 레시피, 위치 정보 등을 수정합니다.")
-  @PutMapping("/api/cards/{cardId}")
+  @PutMapping("/{cardId}")
   public ResponseEntity<ApiResponse<CardDetailResponse>> updateCard(
           HttpServletRequest req,
           @Parameter(description = "수정할 카드 ID", example = "12")

--- a/src/main/java/EatPic/spring/domain/card/converter/CardConverter.java
+++ b/src/main/java/EatPic/spring/domain/card/converter/CardConverter.java
@@ -2,6 +2,7 @@ package EatPic.spring.domain.card.converter;
 
 import EatPic.spring.domain.card.dto.request.CardCreateRequest;
 import EatPic.spring.domain.card.dto.response.CardResponse;
+import EatPic.spring.domain.card.dto.response.CardResponse.CardDeleteResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardDetailResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedUserDTO;
@@ -149,5 +150,12 @@ public class CardConverter {
                 .hashtagName(hashtag.getHashtagName())
                 .card_count(cardCount)
                 .build();
+    }
+
+    public static CardDeleteResponse toCardDeleteResponse(Card card) {
+        return CardDeleteResponse.builder()
+            .cardId(card.getId())
+            .successMessage("카드 삭제 성공")
+            .build();
     }
 }

--- a/src/main/java/EatPic/spring/domain/card/dto/response/CardResponse.java
+++ b/src/main/java/EatPic/spring/domain/card/dto/response/CardResponse.java
@@ -279,6 +279,22 @@ public class CardResponse {
 
   }
 
+  @Builder
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Schema(title = "CardDeleteResponse: 카드 삭제 응답 dto")
+  public static class CardDeleteResponse {
+    @Schema(description = "카드 ID", example = "12")
+    @NotNull
+    private Long cardId;
+
+    @Schema(description = "카드 삭제 성공 메세지", example = "카드 삭제 성공")
+    @NotNull
+    private String successMessage;
+
+  }
+
 
 
 }

--- a/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
@@ -32,6 +32,7 @@ public interface CardRepository extends JpaRepository<Card, Long> {
   Optional<Card> findByIdAndIsDeletedFalse(Long id);
 
   List<Card> findAllByUserAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
+  List<Card> findAllByUserAndIsDeletedFalseAndCreatedAtBetween(User user, LocalDateTime start, LocalDateTime end);
 
 @Query("""
 SELECT DISTINCT c

--- a/src/main/java/EatPic/spring/domain/card/service/CardService.java
+++ b/src/main/java/EatPic/spring/domain/card/service/CardService.java
@@ -3,6 +3,7 @@ package EatPic.spring.domain.card.service;
 import EatPic.spring.domain.card.dto.request.CardCreateRequest;
 import EatPic.spring.domain.card.dto.request.CardCreateRequest.CardUpdateRequest;
 import EatPic.spring.domain.card.dto.response.CardResponse;
+import EatPic.spring.domain.card.dto.response.CardResponse.CardDeleteResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardDetailResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.CardFeedResponse;
 import EatPic.spring.domain.card.dto.response.CardResponse.RecommendCardResponse;
@@ -19,7 +20,7 @@ public interface CardService {
   CardResponse.CreateCardResponse createNewCard(HttpServletRequest req, CardCreateRequest.CreateCardRequest request, User user, MultipartFile cardImageFile);
   CardDetailResponse getCardDetail(Long cardId, Long userId);
   CardFeedResponse getCardFeed(Long cardId, Long userId);
-  void deleteCard(Long cardId, Long userId);
+  CardDeleteResponse deleteCard(Long cardId, Long userId);
   List<TodayCardResponse> getTodayCards(Long userId);
   CardDetailResponse updateCard(Long cardId, User user, CardUpdateRequest request);
   CardResponse.PagedCardFeedResponseDto getCardFeedByCursor(HttpServletRequest request, Long userId, int size, Long cursor);


### PR DESCRIPTION
## #️⃣연관된 이슈

>  #155 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
카드 삭제 시 응답으로 성공메세지와 카드 아이디 반환
여러 api에서 카드 조회 시, 삭제된 카드는 조회되지 않도록 수정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 다른 부분에서도 카드 조회하는 메서드 사용되고 있다면, 이 PR을 참고해서 삭제된 카드는 조회되지 않도록 메서드 다시 설정해주세요
