### PR TITLE
refactor: SearchService 쿼리 최적화

### DIFF
--- a/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
+++ b/src/main/java/EatPic/spring/domain/card/repository/CardRepository.java
@@ -37,12 +37,10 @@ public interface CardRepository extends JpaRepository<Card, Long> {
 @Query("""
 SELECT DISTINCT c
 FROM Card c
-JOIN FETCH c.user u
-LEFT JOIN FETCH c.cardHashtags ch
 WHERE c.isDeleted = false
   AND c.isShared = true
-  AND u.id <> :loginUserId
-  AND u.id NOT IN (
+  AND c.user.id <> :loginUserId
+  AND c.user.id NOT IN (
       SELECT ub.blockedUser.id
       FROM UserBlock ub
       WHERE ub.user.id = :loginUserId
@@ -101,5 +99,15 @@ ORDER BY c.id DESC
       AND c.isShared = true
 """)
   Long countCardsByHashtag(@Param("hashtagId") Long hashtagId);
+
+  @Query("""
+    SELECT ch.hashtag.id, COUNT(ch.card.id)
+    FROM CardHashtag ch
+    WHERE ch.hashtag.id IN :hashtagIds
+      AND ch.card.isDeleted = false
+      AND ch.card.isShared = true
+    GROUP BY ch.hashtag.id
+    """)
+  List<Object[]> countCardsByHashtagIds(@Param("hashtagIds") List<Long> hashtagIds);
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
* 이전 쿼리에서 불필요한 페치조인 있어서 삭제했습니다.
* 해시태그 별 작성된 카드 수 조회 로직에서 card 카운트하는 부분 수정했습니다.
* getHashtagInFollow랑 getHashtagInAll에서 slice -> dto 부분이 겹쳐서 getGetHashtagListResponseDto 메소드 추출했습니다.(인텔리제이가 해줌)

### 스크린샷 (선택)
<img width="2048" height="752" alt="image" src="https://github.com/user-attachments/assets/612dea69-30f1-42b8-b82d-38d02bce50b7" />
<img width="2048" height="377" alt="image" src="https://github.com/user-attachments/assets/7ab172ca-2432-4bc4-a06c-da61b8cd4318" />

<img width="1823" height="1162" alt="image" src="https://github.com/user-attachments/assets/912229d0-2157-41c6-a52b-d09c7caa5a9a" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
