### PR TITLE
Refactor: 팔로워 목록 로직 수정, query 없는 경우 추가

### DIFF
--- a/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
+++ b/src/main/java/EatPic/spring/domain/card/controller/SearchController.java
@@ -92,13 +92,14 @@ public class SearchController {
         return ApiResponse.onSuccess(result);
     }
 
-    @Operation(summary = "해당 유저 팔로우 목록 조회", description = "팔로우 - 해시태그 검색 api")
+    @Operation(summary = "해당 유저 팔로잉,팔로워 검색", description = "FOLLOWING은 유저(userId)가 팔로우 중인 목록을, FOLLOWED는 유저를 팔로우하는 목록을 반환합니다." +
+            "<br> query가 null일 경우 임의의 팔로잉/팔로워 목록을 반환합니다")
     @GetMapping("/followList")
     public ApiResponse<SearchResponseDTO.GetAccountListResponseDtoWithFollow> searchFollowList(
             HttpServletRequest request,
             @RequestParam(value = "follow status")FollowStatus status,
             @RequestParam(value = "userId")Long userId,
-            @RequestParam(value = "query") String query,
+            @RequestParam(value = "query", required = false) String query,
             @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
             @RequestParam(value = "cursor", required = false) Long cursor
     ) {

--- a/src/main/java/EatPic/spring/domain/card/service/SearchServiceImpl.java
+++ b/src/main/java/EatPic/spring/domain/card/service/SearchServiceImpl.java
@@ -211,12 +211,16 @@ public class SearchServiceImpl implements SearchService {
 
         User me = userService.getLoginUser(request);
 
+        if(query == null){
+
+        }
+
         // 페이징 처리 하기
         Pageable pageable = PageRequest.of(0, limit + 1, Sort.by("id").ascending());
         Slice<User> users = new SliceImpl<>(Collections.emptyList(), pageable, false);
         switch(status){
             case FOLLOWED -> { // 해당 유저를 팔로우한 사람 목록
-                users = userRepository.searchAccountNotInFollow(query, cursor, pageable, userId);
+                users = userRepository.searchAccountInFollower(query, cursor, pageable, userId);
             }
             case FOLLOWING -> { // 해당 유저가 팔로우한 사람 목록
                 users = userRepository.searchAccountInFollow(query, cursor, pageable, userId);
@@ -234,12 +238,10 @@ public class SearchServiceImpl implements SearchService {
         // 내가 팔로우한 유저 목록
         Set<Long> alreadyFollowedIdSet = new HashSet<>(userFollowRepository.findFollowingUserIds(me.getId()));
 
-
-
         List<SearchResponseDTO.GetAccountResponseDtoWithFollow> result = users.getContent().stream()
                 .map(user -> UserConverter.toAccountDtoWithFollow(
                         user,
-                        alreadyFollowedIdSet.contains(user.getId()))
+                        alreadyFollowedIdSet.contains(user.getId())) // 내 기준 팔로우 여부 표시
                 ).toList();
 
 

--- a/src/main/java/EatPic/spring/domain/card/service/SearchServiceImpl.java
+++ b/src/main/java/EatPic/spring/domain/card/service/SearchServiceImpl.java
@@ -211,10 +211,6 @@ public class SearchServiceImpl implements SearchService {
 
         User me = userService.getLoginUser(request);
 
-        if(query == null){
-
-        }
-
         // 페이징 처리 하기
         Pageable pageable = PageRequest.of(0, limit + 1, Sort.by("id").ascending());
         Slice<User> users = new SliceImpl<>(Collections.emptyList(), pageable, false);

--- a/src/main/java/EatPic/spring/domain/user/repository/UserRepository.java
+++ b/src/main/java/EatPic/spring/domain/user/repository/UserRepository.java
@@ -40,8 +40,8 @@ public interface UserRepository extends JpaRepository<User,Long> {
     WHERE uf.user.id = :loginUserId
       AND (:cursor IS NULL OR u.id > :cursor)
       AND (:query IS NULL OR 
-        LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
-        OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%')))
+        (LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
+        OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%'))))
     ORDER BY u.id ASC
 """)
     Slice<User> searchAccountInFollow(@Param("query") String query,
@@ -56,8 +56,8 @@ public interface UserRepository extends JpaRepository<User,Long> {
     WHERE uf.targetUser.id = :loginUserId
       AND (:cursor IS NULL OR u.id > :cursor)
       AND (:query IS NULL OR
-       LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
-       OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%')))
+       (LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
+       OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%'))))
     ORDER BY u.id ASC
 """)
     Slice<User> searchAccountInFollower(@Param("query") String query,

--- a/src/main/java/EatPic/spring/domain/user/repository/UserRepository.java
+++ b/src/main/java/EatPic/spring/domain/user/repository/UserRepository.java
@@ -39,11 +39,28 @@ public interface UserRepository extends JpaRepository<User,Long> {
     JOIN UserFollow uf ON u.id = uf.targetUser.id
     WHERE uf.user.id = :loginUserId
       AND (:cursor IS NULL OR u.id > :cursor)
-      AND (LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
-           OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%')))
+      AND (:query IS NULL OR 
+        LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
+        OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%')))
     ORDER BY u.id ASC
 """)
     Slice<User> searchAccountInFollow(@Param("query") String query,
+                                      @Param("cursor") Long cursor,
+                                      Pageable pageable,
+                                      @Param("loginUserId") Long userId);
+
+    @Query("""
+    SELECT u
+    FROM User u
+    JOIN UserFollow uf ON u.id = uf.user.id
+    WHERE uf.targetUser.id = :loginUserId
+      AND (:cursor IS NULL OR u.id > :cursor)
+      AND (:query IS NULL OR
+       LOWER(u.nameId) LIKE LOWER(CONCAT(:query, '%'))
+       OR LOWER(u.nickname) LIKE LOWER(CONCAT(:query, '%')))
+    ORDER BY u.id ASC
+""")
+    Slice<User> searchAccountInFollower(@Param("query") String query,
                                       @Param("cursor") Long cursor,
                                       Pageable pageable,
                                       @Param("loginUserId") Long userId);
@@ -74,19 +91,5 @@ public interface UserRepository extends JpaRepository<User,Long> {
 //                                      @Param("loginUserId") Long userId);
 
 
-    @Query("""
-    SELECT u
-    FROM User u
-    WHERE u.id NOT IN (
-        SELECT uf.targetUser.id
-        FROM UserFollow uf
-        WHERE uf.user.id = :loginUserId
-    )
-    AND (:cursor IS NULL OR u.id > :cursor)
-    AND u.nickname LIKE %:query%
-    ORDER BY u.id ASC
-    """)
-    Slice<User> searchAccountNotInFollow(@Param("query") String query,
-            @Param("cursor") Long cursor, Pageable pageable, @Param("loginUserId") Long userId);
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> 182

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
목록 조회 화면 처음에 들어갔을 때 검색하기 전에도 목록이 떠야 하므로 query를 null 허용 했고 이에 따른 repository메소드 @Query
부분도 수정했습니다 
### 스크린샷 (선택)
<img width="236" height="250" alt="image" src="https://github.com/user-attachments/assets/925e0ff5-11fa-43c4-8c52-9997260e1166" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
